### PR TITLE
Fix lightClientOptimisiticUpdate to respect min sig requirement

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -89,7 +89,6 @@ func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed inte
 	postState state.BeaconState) (int, error) {
 	// Determine slots per period
 	config := params.BeaconConfig()
-	slotsPerPeriod := uint64(config.EpochsPerSyncCommitteePeriod) * uint64(config.SlotsPerEpoch)
 
 	// Get attested state
 	attestedRoot := signed.Block().ParentRoot()
@@ -112,7 +111,6 @@ func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed inte
 	update, err := lightclienthelpers.NewLightClientFinalityUpdateFromBeaconState(
 		ctx,
 		config,
-		slotsPerPeriod,
 		postState,
 		signed,
 		attestedState,

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -50,7 +50,6 @@ func (s *Service) sendLightClientOptimisticUpdate(ctx context.Context, signed in
 	postState state.BeaconState) (int, error) {
 	// Determine slots per period
 	config := params.BeaconConfig()
-	slotsPerPeriod := uint64(config.EpochsPerSyncCommitteePeriod) * uint64(config.SlotsPerEpoch)
 
 	// Get attested state
 	attestedRoot := signed.Block().ParentRoot()
@@ -59,25 +58,12 @@ func (s *Service) sendLightClientOptimisticUpdate(ctx context.Context, signed in
 		return 0, errors.Wrap(err, "could not get attested state")
 	}
 
-	// Get finalized block
-	var finalizedBlock interfaces.SignedBeaconBlock
-	finalizedCheckPoint := attestedState.FinalizedCheckpoint()
-	if finalizedCheckPoint != nil {
-		finalizedRoot := bytesutil.ToBytes32(finalizedCheckPoint.Root)
-		finalizedBlock, err = s.cfg.BeaconDB.Block(ctx, finalizedRoot)
-		if err != nil {
-			finalizedBlock = nil
-		}
-	}
-
 	update, err := lightclienthelpers.NewLightClientOptimisticUpdateFromBeaconState(
 		ctx,
 		config,
-		slotsPerPeriod,
 		postState,
 		signed,
 		attestedState,
-		finalizedBlock,
 	)
 
 	if err != nil {

--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -297,16 +297,17 @@ func (bs *Server) GetLightClientOptimisticUpdate(ctx context.Context,
 			return nil, status.Errorf(codes.Internal, "Could not get parent block: %v", err)
 		}
 
+		// Get the number of sync committee signatures
 		numOfSyncCommitteeSignatures = 0
 		if syncAggregate, err := block.Block().Body().SyncAggregate(); err == nil {
 			numOfSyncCommitteeSignatures = syncAggregate.SyncCommitteeBits.Count()
 		}
-	}
 
-	// Get the state
-	state, err = bs.StateFetcher.StateBySlot(ctx, block.Block().Slot())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get state: %v", err)
+		// Get the state
+		state, err = bs.StateFetcher.StateBySlot(ctx, block.Block().Slot())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get state: %v", err)
+		}
 	}
 
 	// Get attested state

--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -289,6 +289,7 @@ func (bs *Server) GetLightClientOptimisticUpdate(ctx context.Context,
 		numOfSyncCommitteeSignatures = syncAggregate.SyncCommitteeBits.Count()
 	}
 
+	var blockChanged bool
 	for numOfSyncCommitteeSignatures < config.MinSyncCommitteeParticipants {
 		// Get the parent block
 		parentRoot := block.Block().ParentRoot()
@@ -303,7 +304,11 @@ func (bs *Server) GetLightClientOptimisticUpdate(ctx context.Context,
 			numOfSyncCommitteeSignatures = syncAggregate.SyncCommitteeBits.Count()
 		}
 
-		// Get the state
+		blockChanged = true
+	}
+
+	if blockChanged {
+		// Get the new state
 		state, err = bs.StateFetcher.StateBySlot(ctx, block.Block().Slot())
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not get state: %v", err)

--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -261,7 +261,6 @@ func (bs *Server) GetLightClientOptimisticUpdate(ctx context.Context,
 
 	// Determine slots per period
 	config := params.BeaconConfig()
-	slotsPerPeriod := uint64(config.EpochsPerSyncCommitteePeriod) * uint64(config.SlotsPerEpoch)
 
 	// Get the current state
 	state, err := bs.HeadFetcher.HeadState(ctx)
@@ -299,25 +298,12 @@ func (bs *Server) GetLightClientOptimisticUpdate(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "Could not get attested state: %v", err)
 	}
 
-	// Get finalized block
-	var finalizedBlock interfaces.SignedBeaconBlock
-	finalizedCheckPoint := attestedState.FinalizedCheckpoint()
-	if finalizedCheckPoint != nil {
-		finalizedRoot := bytesutil.ToBytes32(finalizedCheckPoint.Root)
-		finalizedBlock, err = bs.BeaconDB.Block(ctx, finalizedRoot)
-		if err != nil {
-			finalizedBlock = nil
-		}
-	}
-
 	update, err := lightclienthelpers.NewLightClientOptimisticUpdateFromBeaconState(
 		ctx,
 		config,
-		slotsPerPeriod,
 		state,
 		block,
 		attestedState,
-		finalizedBlock,
 	)
 
 	if err != nil {

--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -178,7 +178,6 @@ func (bs *Server) GetLightClientFinalityUpdate(ctx context.Context,
 
 	// Determine slots per period
 	config := params.BeaconConfig()
-	slotsPerPeriod := uint64(config.EpochsPerSyncCommitteePeriod) * uint64(config.SlotsPerEpoch)
 
 	// Get the current state
 	state, err := bs.HeadFetcher.HeadState(ctx)
@@ -230,7 +229,6 @@ func (bs *Server) GetLightClientFinalityUpdate(ctx context.Context,
 	update, err := lightclienthelpers.NewLightClientFinalityUpdateFromBeaconState(
 		ctx,
 		config,
-		slotsPerPeriod,
 		state,
 		block,
 		attestedState,

--- a/beacon-chain/rpc/eth/helpers/lightclient/lightclient.go
+++ b/beacon-chain/rpc/eth/helpers/lightclient/lightclient.go
@@ -182,7 +182,6 @@ func NewLightClientOptimisticUpdateFromBeaconState(
 func NewLightClientFinalityUpdateFromBeaconState(
 	ctx context.Context,
 	config *params.BeaconChainConfig,
-	slotsPerPeriod uint64,
 	state state.BeaconState,
 	block interfaces.SignedBeaconBlock,
 	attestedState state.BeaconState,
@@ -323,7 +322,7 @@ func NewLightClientUpdateFromBeaconState(
 	attestedState state.BeaconState,
 	finalizedBlock interfaces.SignedBeaconBlock) (*ethpbv2.LightClientUpdate, error) {
 
-	result, err := NewLightClientFinalityUpdateFromBeaconState(ctx, config, slotsPerPeriod, state, block, attestedState,
+	result, err := NewLightClientFinalityUpdateFromBeaconState(ctx, config, state, block, attestedState,
 		finalizedBlock)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/rpc/eth/helpers/lightclient/lightclient.go
+++ b/beacon-chain/rpc/eth/helpers/lightclient/lightclient.go
@@ -88,11 +88,9 @@ func NewLightClientBootstrapFromBeaconState(ctx context.Context, state state.Bea
 func NewLightClientOptimisticUpdateFromBeaconState(
 	ctx context.Context,
 	config *params.BeaconChainConfig,
-	_ uint64,
 	state state.BeaconState,
 	block interfaces.SignedBeaconBlock,
-	attestedState state.BeaconState,
-	_ interfaces.SignedBeaconBlock) (*ethpbv2.LightClientUpdate, error) {
+	attestedState state.BeaconState) (*ethpbv2.LightClientUpdate, error) {
 
 	// assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
 	attestedEpoch := types.Epoch(uint64(attestedState.Slot()) / uint64(config.SlotsPerEpoch))
@@ -190,8 +188,13 @@ func NewLightClientFinalityUpdateFromBeaconState(
 	attestedState state.BeaconState,
 	finalizedBlock interfaces.SignedBeaconBlock) (*ethpbv2.LightClientUpdate, error) {
 
-	result, err := NewLightClientOptimisticUpdateFromBeaconState(ctx, config, slotsPerPeriod, state, block,
-		attestedState, finalizedBlock)
+	result, err := NewLightClientOptimisticUpdateFromBeaconState(
+		ctx,
+		config,
+		state,
+		block,
+		attestedState,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
The existing implementation for endpoint `light_client_optimisitic_update` won't respect the full node configuration `minSyncCommitteeSigRequires`, therefore need a patch

**Which issues(s) does this PR fix?**
See above.

Fixes #

**Other notes for review**
There is also other refactoring to existing code to remove some unused function arguments.  (Simply the logic)