### PR TITLE
Light Client full updates need super majority

### DIFF
--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -103,10 +103,33 @@ func (bs *Server) GetLightClientUpdatesByRange(ctx context.Context, req *ethpbv2
 		lFirstSlotInPeriod := period * slotsPerPeriod
 
 		var state state.BeaconState
+		var block interfaces.SignedBeaconBlock
 		for lSlot := lLastSlotInPeriod; lSlot >= lFirstSlotInPeriod; lSlot-- {
 			state, err = bs.StateFetcher.StateBySlot(ctx, types.Slot(lSlot))
 			if err == nil {
 				break
+			}
+
+			// Get the block
+			header := state.LatestBlockHeader()
+			blockRoot, err := header.HashTreeRoot()
+			if err != nil {
+				continue
+			}
+
+			block, err = bs.BeaconDB.Block(ctx, blockRoot)
+			if err != nil {
+				continue
+			}
+
+			syncAggregate, err := block.Block().Body().SyncAggregate()
+			if err != nil || syncAggregate == nil {
+				continue
+			}
+
+			if syncAggregate.SyncCommitteeBits.Count()*3 < config.SyncCommitteeSize*2 {
+				// Not enough votes
+				continue
 			}
 		}
 
@@ -114,14 +137,6 @@ func (bs *Server) GetLightClientUpdatesByRange(ctx context.Context, req *ethpbv2
 			// No valid state found for the period
 			continue
 		}
-
-		// Get the block
-		slot := state.Slot()
-		blocks, err := bs.BeaconDB.BlocksBySlot(ctx, slot)
-		if err != nil || len(blocks) == 0 {
-			continue
-		}
-		block := blocks[0]
 
 		// Get attested state
 		attestedRoot := block.Block().ParentRoot()
@@ -328,7 +343,7 @@ func (bs *Server) getLightClientEventBlock(ctx context.Context, minSignaturesReq
 
 	// Loop through the blocks until we find a block that has super majority of sync committee signatures (2/3)
 	var numOfSyncCommitteeSignatures uint64
-	if syncAggregate, err := block.Block().Body().SyncAggregate(); err == nil {
+	if syncAggregate, err := block.Block().Body().SyncAggregate(); err == nil && syncAggregate != nil {
 		numOfSyncCommitteeSignatures = syncAggregate.SyncCommitteeBits.Count()
 	}
 
@@ -342,7 +357,7 @@ func (bs *Server) getLightClientEventBlock(ctx context.Context, minSignaturesReq
 
 		// Get the number of sync committee signatures
 		numOfSyncCommitteeSignatures = 0
-		if syncAggregate, err := block.Block().Body().SyncAggregate(); err == nil {
+		if syncAggregate, err := block.Block().Body().SyncAggregate(); err == nil && syncAggregate != nil {
 			numOfSyncCommitteeSignatures = syncAggregate.SyncCommitteeBits.Count()
 		}
 	}

--- a/beacon-chain/rpc/eth/beacon/lightclient.go
+++ b/beacon-chain/rpc/eth/beacon/lightclient.go
@@ -73,6 +73,12 @@ func (bs *Server) GetLightClientUpdatesByRange(ctx context.Context, req *ethpbv2
 	startPeriod := req.StartPeriod
 	endPeriod := startPeriod + count - 1
 
+	// The end of start period must be later than Altair fork epoch, otherwise, can not get the sync committee votes
+	startPeriodEndSlot := (startPeriod+1)*slotsPerPeriod - 1
+	if startPeriodEndSlot < uint64(config.AltairForkEpoch)*uint64(config.SlotsPerEpoch) {
+		startPeriod = uint64(config.AltairForkEpoch) * uint64(config.SlotsPerEpoch) / slotsPerPeriod
+	}
+
 	headState, err := bs.HeadFetcher.HeadState(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
Current impl doesn't require super majority to publish a `full update`, which isn't correct.   (On a separate PR, we patch the spec as well)

`full update` provides both finality checkpoints as well as `next_sync_committee`, which is one thing to be treat as `source of truth` for next round, and on the light client side, it will accept the first-seen one in the whole sync period. 

Therefore, we need to patch this to only respond when there is 2/3 sync committee votes. 

**Which issues(s) does this PR fix?**
See above. 

**Other notes for review**
