### PR TITLE
chore: switch the standard image build target to polymerdao

### DIFF
--- a/cmd/beacon-chain/BUILD.bazel
+++ b/cmd/beacon-chain/BUILD.bazel
@@ -66,10 +66,10 @@ container_image(
 container_bundle(
     name = "image_bundle",
     images = {
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest": ":image_with_creation_time",
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}": ":image_with_creation_time",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest": ":image_with_creation_time",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}": ":image_with_creation_time",
+        "gcr.io/polymerdao/prysm/beacon-chain:latest": ":image_with_creation_time",
+        "gcr.io/polymerdao/prysm/beacon-chain:{DOCKER_TAG}": ":image_with_creation_time",
+        "index.docker.io/polymerdao/prysm-beacon-chain:latest": ":image_with_creation_time",
+        "index.docker.io/polymerdao/prysm-beacon-chain:{DOCKER_TAG}": ":image_with_creation_time",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],
@@ -85,10 +85,10 @@ go_image_debug(
 container_bundle(
     name = "image_bundle_debug",
     images = {
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-debug": ":image_debug",
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-debug": ":image_debug",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
+        "gcr.io/polymerdao/prysm/beacon-chain:latest-debug": ":image_debug",
+        "gcr.io/polymerdao/prysm/beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
+        "index.docker.io/polymerdao/prysm-beacon-chain:latest-debug": ":image_debug",
+        "index.docker.io/polymerdao/prysm-beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],
@@ -104,10 +104,10 @@ go_image_alpine(
 container_bundle(
     name = "image_bundle_alpine",
     images = {
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-alpine": ":image_alpine",
-        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-alpine": ":image_alpine",
-        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
+        "gcr.io/polymerdao/prysm/beacon-chain:latest-alpine": ":image_alpine",
+        "gcr.io/polymerdao/prysm/beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
+        "index.docker.io/polymerdao/prysm-beacon-chain:latest-alpine": ":image_alpine",
+        "index.docker.io/polymerdao/prysm-beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
     },
     tags = ["manual"],
     visibility = ["//beacon-chain:__pkg__"],

--- a/hack/tag-versioned-docker-images.sh
+++ b/hack/tag-versioned-docker-images.sh
@@ -6,14 +6,14 @@
 # List of docker tags to update with git versioned tag.
 DOCKER_IMAGES=(
   # Beacon chain images
-  "gcr.io/prysmaticlabs/prysm/beacon-chain"
-  "index.docker.io/prysmaticlabs/prysm-beacon-chain"
+  "gcr.io/polymerdao/prysm/beacon-chain"
+  "index.docker.io/polymerdao/prysm-beacon-chain"
   # Validator images
-  "gcr.io/prysmaticlabs/prysm/validator"
-  "index.docker.io/prysmaticlabs/prysm-validator"
+  "gcr.io/polymerdao/prysm/validator"
+  "index.docker.io/polymerdao/prysm-validator"
   # Slasher images
-  "gcr.io/prysmaticlabs/prysm/slasher"
-  "index.docker.io/prysmaticlabs/prysm-slasher"
+  "gcr.io/polymerdao/prysm/slasher"
+  "index.docker.io/polymerdao/prysm-slasher"
 )
 
 


### PR DESCRIPTION
* bazel run //cmd/beacon-chain:image_bundle
* docker login ghcr.io .......... (regular login)
* docker tag gcr.io/polymerdao/prysm/beacon-chain:xxxxx ghcr.io/polymerdao/prysm-beacon-chain:xxxxxx
* docker push ghcr.io/polymerdao/prysm-beacon-chain:xxxxxx